### PR TITLE
Encode database names and document Ids used n Urls

### DIFF
--- a/scripts/attachment.js
+++ b/scripts/attachment.js
@@ -30,7 +30,7 @@ var Attachment = function (slouch) {
 
 Attachment.prototype.get = function (dbName, docId, attachmentName) {
   return this._slouch._req({
-    uri: this._slouch._url + '/' + dbName + '/' + docId + '/' + attachmentName,
+    uri: this._slouch._url + '/' + encodeURIComponent(dbName) + '/' + encodeURIComponent(docId) + '/' + encodeURIComponent(attachmentName),
     method: 'GET',
     raw: true,
     encoding: null
@@ -41,7 +41,7 @@ Attachment.prototype.get = function (dbName, docId, attachmentName) {
 
 Attachment.prototype.destroy = function (dbName, docId, attachmentName, rev) {
   return this._slouch._req({
-    uri: this._slouch._url + '/' + dbName + '/' + docId + '/' + attachmentName,
+    uri: this._slouch._url + '/' + encodeURIComponent(dbName) + '/' + encodeURIComponent(docId) + '/' + encodeURIComponent(attachmentName),
     method: 'DELETE',
     qs: {
       rev: rev

--- a/scripts/attachment.js
+++ b/scripts/attachment.js
@@ -30,7 +30,8 @@ var Attachment = function (slouch) {
 
 Attachment.prototype.get = function (dbName, docId, attachmentName) {
   return this._slouch._req({
-    uri: this._slouch._url + '/' + encodeURIComponent(dbName) + '/' + encodeURIComponent(docId) + '/' + encodeURIComponent(attachmentName),
+    uri: this._slouch._url + '/' + encodeURIComponent(dbName) + '/' + encodeURIComponent(
+      docId) + '/' + encodeURIComponent(attachmentName),
     method: 'GET',
     raw: true,
     encoding: null
@@ -41,7 +42,8 @@ Attachment.prototype.get = function (dbName, docId, attachmentName) {
 
 Attachment.prototype.destroy = function (dbName, docId, attachmentName, rev) {
   return this._slouch._req({
-    uri: this._slouch._url + '/' + encodeURIComponent(dbName) + '/' + encodeURIComponent(docId) + '/' + encodeURIComponent(attachmentName),
+    uri: this._slouch._url + '/' + encodeURIComponent(dbName) + '/' + encodeURIComponent(
+      docId) + '/' + encodeURIComponent(attachmentName),
     method: 'DELETE',
     qs: {
       rev: rev

--- a/scripts/db.js
+++ b/scripts/db.js
@@ -117,15 +117,21 @@ DB.prototype.changesArray = function (dbName, params) {
 };
 
 DB.prototype.view = function (dbName, viewDocId, view, params) {
+  var encodedViewDocId = '_design/' + encodeURIComponent(viewDocId.substr(8));
   return new CouchPersistentStreamIterator({
-    url: this._slouch._url + '/' + encodeURIComponent(dbName) + '/' + viewDocId + '/_view/' + view,
+    url: this._slouch._url + '/' + encodeURIComponent(dbName) + '/' + encodedViewDocId +
+      '/_view/' +
+      view,
     qs: params
   }, 'rows.*');
 };
 
 DB.prototype.viewArray = function (dbName, viewDocId, view, params) {
+  var encodedViewDocId = '_design/' + encodeURIComponent(viewDocId.substr(8));
   return this._slouch._req({
-    url: this._slouch._url + '/' + encodeURIComponent(dbName) + '/' + viewDocId + '/_view/' + view,
+    url: this._slouch._url + '/' + encodeURIComponent(dbName) + '/' + encodedViewDocId +
+      '/_view/' +
+      view,
     qs: params,
     parseBody: true
   });

--- a/scripts/db.js
+++ b/scripts/db.js
@@ -9,7 +9,7 @@ var DB = function (slouch) {
 
 DB.prototype._create = function (dbName) {
   return this._slouch._req({
-    uri: this._slouch._url + '/' + dbName,
+    uri: this._slouch._url + '/' + encodeURIComponent(dbName),
     method: 'PUT'
   });
 };
@@ -31,7 +31,7 @@ DB.prototype.create = function (dbName) {
 
 DB.prototype.destroy = function (dbName) {
   return this._slouch._req({
-    uri: this._slouch._url + '/' + dbName,
+    uri: this._slouch._url + '/' + encodeURIComponent(dbName),
     method: 'DELETE',
     parseBody: true
   });
@@ -39,7 +39,7 @@ DB.prototype.destroy = function (dbName) {
 
 DB.prototype.get = function (dbName) {
   return this._slouch._req({
-    uri: this._slouch._url + '/' + dbName,
+    uri: this._slouch._url + '/' + encodeURIComponent(dbName),
     method: 'GET',
     parseBody: true
   });
@@ -47,7 +47,7 @@ DB.prototype.get = function (dbName) {
 
 DB.prototype.exists = function (dbName) {
   return this._slouch._req({
-    uri: this._slouch._url + '/' + dbName,
+    uri: this._slouch._url + '/' + encodeURIComponent(dbName),
     method: 'GET'
   }).then(function () {
     return true;
@@ -110,7 +110,7 @@ DB.prototype.changes = function (dbName, params) {
 
 DB.prototype.changesArray = function (dbName, params) {
   return this._slouch._req({
-    url: this._slouch._url + '/' + dbName + '/_changes',
+    url: this._slouch._url + '/' + encodeURIComponent(dbName) + '/_changes',
     qs: params,
     parseBody: true
   });
@@ -118,14 +118,14 @@ DB.prototype.changesArray = function (dbName, params) {
 
 DB.prototype.view = function (dbName, viewDocId, view, params) {
   return new CouchPersistentStreamIterator({
-    url: this._slouch._url + '/' + dbName + '/' + viewDocId + '/_view/' + view,
+    url: this._slouch._url + '/' + encodeURIComponent(dbName) + '/' + viewDocId + '/_view/' + view,
     qs: params
   }, 'rows.*');
 };
 
 DB.prototype.viewArray = function (dbName, viewDocId, view, params) {
   return this._slouch._req({
-    url: this._slouch._url + '/' + dbName + '/' + viewDocId + '/_view/' + view,
+    url: this._slouch._url + '/' + encodeURIComponent(dbName) + '/' + viewDocId + '/_view/' + view,
     qs: params,
     parseBody: true
   });

--- a/scripts/doc.js
+++ b/scripts/doc.js
@@ -48,7 +48,7 @@ Doc.prototype.ignoreMissing = function (promiseFactory) {
 
 Doc.prototype.create = function (dbName, doc) {
   return this._slouch._req({
-    uri: this._slouch._url + '/' + dbName,
+    uri: this._slouch._url + '/' + encodeURIComponent(dbName),
     method: 'POST',
     json: doc
   }).then(function (response) {
@@ -65,7 +65,7 @@ Doc.prototype.createAndIgnoreConflict = function (dbName, doc) {
 
 Doc.prototype.update = function (dbName, doc) {
   return this._slouch._req({
-    uri: this._slouch._url + '/' + dbName + '/' + doc._id,
+    uri: this._slouch._url + '/' + encodeURIComponent(dbName) + '/' + encodeURIComponent(doc._id),
     method: 'PUT',
     body: JSON.stringify(doc),
     parseBody: true
@@ -87,7 +87,7 @@ Doc.prototype.updateIgnoreConflict = function (dbName, doc) {
 
 Doc.prototype.get = function (dbName, docId, params) {
   return this._slouch._req({
-    uri: this._slouch._url + '/' + dbName + '/' + docId,
+    uri: this._slouch._url + '/' + encodeURIComponent(dbName) + '/' + encodeURIComponent(docId),
     method: 'GET',
     qs: params,
     parseBody: true
@@ -281,7 +281,7 @@ Doc.prototype.getModifyUpsert = function (dbName, docId, onGetPromiseFactory) {
 
 Doc.prototype.allArray = function (dbName, params) {
   return this._slouch._req({
-    uri: this._slouch._url + '/' + dbName + '/_all_docs',
+    uri: this._slouch._url + '/' + encodeURIComponent(dbName) + '/_all_docs',
     method: 'GET',
     qs: params,
     parseBody: true
@@ -291,7 +291,7 @@ Doc.prototype.allArray = function (dbName, params) {
 // Use a JSONStream so that we don't have to load a large JSON structure into memory
 Doc.prototype.all = function (dbName, params) {
   return new CouchPersistentStreamIterator({
-    url: this._slouch._url + '/' + dbName + '/_all_docs',
+    url: this._slouch._url + '/' + encodeURIComponent(dbName) + '/_all_docs',
     method: 'GET',
     qs: params
   }, 'rows.*', null, this._slouch._request);
@@ -313,7 +313,7 @@ Doc.prototype.destroyAll = function (dbName, keepDesignDocs) {
 
 Doc.prototype.destroy = function (dbName, docId, docRev) {
   return this._slouch._req({
-    uri: this._slouch._url + '/' + dbName + '/' + docId,
+    uri: this._slouch._url + '/' + encodeURIComponent(dbName) + '/' + encodeURIComponent(docId),
     method: 'DELETE',
     qs: {
       rev: docRev
@@ -350,7 +350,7 @@ Doc.prototype.setDestroyed = function (doc) {
 
 Doc.prototype.bulkCreateOrUpdate = function (dbName, docs) {
   return this._slouch._req({
-    uri: this._slouch._url + '/' + dbName + '/_bulk_docs',
+    uri: this._slouch._url + '/' + encodeURIComponent(dbName) + '/_bulk_docs',
     method: 'POST',
     json: {
       docs: docs

--- a/scripts/doc.js
+++ b/scripts/doc.js
@@ -87,7 +87,8 @@ Doc.prototype.updateIgnoreConflict = function (dbName, doc) {
 
 Doc.prototype.get = function (dbName, docId, params) {
   return this._slouch._req({
-    uri: this._slouch._url + '/' + encodeURIComponent(dbName) + '/' + encodeURIComponent(docId),
+    uri: this._slouch._url + '/' + encodeURIComponent(dbName) + '/' + encodeURIComponent(
+      docId),
     method: 'GET',
     qs: params,
     parseBody: true
@@ -313,7 +314,8 @@ Doc.prototype.destroyAll = function (dbName, keepDesignDocs) {
 
 Doc.prototype.destroy = function (dbName, docId, docRev) {
   return this._slouch._req({
-    uri: this._slouch._url + '/' + encodeURIComponent(dbName) + '/' + encodeURIComponent(docId),
+    uri: this._slouch._url + '/' + encodeURIComponent(dbName) + '/' + encodeURIComponent(
+      docId),
     method: 'DELETE',
     qs: {
       rev: docRev

--- a/scripts/security.js
+++ b/scripts/security.js
@@ -17,7 +17,7 @@ var Security = function (slouch) {
 // }
 Security.prototype.set = function (dbName, security) {
   return this._slouch._req({
-    uri: this._slouch._url + '/' + dbName + '/_security',
+    uri: this._slouch._url + '/' + encodeURIComponent(dbName) + '/_security',
     method: 'PUT',
     body: JSON.stringify(security)
   });
@@ -25,7 +25,7 @@ Security.prototype.set = function (dbName, security) {
 
 Security.prototype.get = function (dbName) {
   return this._slouch._req({
-    uri: this._slouch._url + '/' + dbName + '/_security',
+    uri: this._slouch._url + '/' + encodeURIComponent(dbName) + '/_security',
     method: 'GET',
     parseBody: true
   });

--- a/test/spec/attachment.js
+++ b/test/spec/attachment.js
@@ -50,15 +50,15 @@ describe('attachment', function () {
   };
 
   var createBase64AttachmentWithSlash = function (dbName, docId, attachmentId) {
-    return slouch.doc.update(dbName, {
+    var doc = {
       _id: docId,
-      _attachments: {
-        [attachmentId]: {
-          data: base64Data,
-          content_type: 'image/png'
-        }
-      }
-    });
+      _attachments: {}
+    };
+    doc._attachments[attachmentId] = {
+      data: base64Data,
+      content_type: 'image/png'
+    };
+    return slouch.doc.update(dbName, doc);
   };
 
   // TODO
@@ -105,7 +105,7 @@ describe('attachment', function () {
     var attachmentId = 'my/image.png';
     return db.create(dbName)
       .then(function () {
-        return createBase64AttachmentWithSlash(dbName, docId, attachmentId)
+        return createBase64AttachmentWithSlash(dbName, docId, attachmentId);
       })
       .then(function () {
         return slouch.doc.get(dbName, docId);
@@ -126,7 +126,7 @@ describe('attachment', function () {
     var attachmentId = 'my/image.png';
     return db.create(dbName)
       .then(function () {
-        return createBase64AttachmentWithSlash(dbName, docId, attachmentId)
+        return createBase64AttachmentWithSlash(dbName, docId, attachmentId);
       })
       .then(function () {
         return slouch.doc.get(dbName, docId);

--- a/test/spec/attachment.js
+++ b/test/spec/attachment.js
@@ -49,6 +49,18 @@ describe('attachment', function () {
     });
   };
 
+  var createBase64AttachmentWithSlash = function (dbName, docId, attachmentId) {
+    return slouch.doc.update(dbName, {
+      _id: docId,
+      _attachments: {
+        [attachmentId]: {
+          data: base64Data,
+          content_type: 'image/png'
+        }
+      }
+    });
+  };
+
   // TODO
   // it('should create attachment', function () {
   //   var data = bufferFrom(base64Data);
@@ -87,4 +99,44 @@ describe('attachment', function () {
     });
   });
 
+  it('should create attachment from base 64 data with slash in name', function () {
+    var dbName = utils.createdDB + '/test';
+    var docId = 'foo/bar';
+    var attachmentId = 'my/image.png';
+    return db.create(dbName)
+      .then(function () {
+        return createBase64AttachmentWithSlash(dbName, docId, attachmentId)
+      })
+      .then(function () {
+        return slouch.doc.get(dbName, docId);
+      }).then(function (doc) {
+        doc._attachments[attachmentId].content_type.should.eql('image/png');
+
+        return slouch.attachment.get(dbName, docId, attachmentId);
+      }).then(function (attachment) {
+        var base64Attach = new Buffer(attachment).toString('base64');
+        base64Attach.should.eql(base64Data);
+        return db.destroy(dbName);
+      });
+  });
+
+  it('should destroy attachment with slash in name', function () {
+    var dbName = utils.createdDB + '/test';
+    var docId = 'foo/bar';
+    var attachmentId = 'my/image.png';
+    return db.create(dbName)
+      .then(function () {
+        return createBase64AttachmentWithSlash(dbName, docId, attachmentId)
+      })
+      .then(function () {
+        return slouch.doc.get(dbName, docId);
+      }).then(function (doc) {
+        return slouch.attachment.destroy(dbName, docId, attachmentId, doc._rev);
+      }).then(function () {
+        return slouch.doc.get(dbName, docId);
+      }).then(function (doc) {
+        (doc._attachments === undefined).should.eql(true);
+        return db.destroy(dbName);
+      });
+  });
 });

--- a/test/spec/db.js
+++ b/test/spec/db.js
@@ -387,7 +387,7 @@ describe('db', function () {
   });
 
   it('show create db with slash in name', function () {
-    const dbName = this.createdDB + '/test';
+    var dbName = this.createdDB + '/test';
     return db.create(dbName)
       .then(function () {
         dbsToDestroy.push(dbName);
@@ -395,11 +395,11 @@ describe('db', function () {
       })
       .then(function (exists) {
         exists.should.eql(true);
-      })
+      });
   });
 
   it('show get a db with slash in name', function () {
-    const dbName = this.createdDB + '/test';
+    var dbName = this.createdDB + '/test';
     return db.create(dbName)
       .then(function () {
         dbsToDestroy.push(dbName);
@@ -407,7 +407,7 @@ describe('db', function () {
       })
       .then(function (_db) {
         _db.db_name.should.eql(dbName);
-      })
+      });
   });
 
   it('should get view with slash in id', function () {
@@ -417,7 +417,7 @@ describe('db', function () {
     return db.create(dbName)
       .then(function () {
         dbsToDestroy.push(dbName);
-        return createDocs(dbName)
+        return createDocs(dbName);
       })
       .then(function () {
         return createView(dbName, viewDocId);
@@ -443,7 +443,7 @@ describe('db', function () {
     return db.create(dbName)
       .then(function () {
         dbsToDestroy.push(dbName);
-        return createDocs(dbName)
+        return createDocs(dbName);
       })
       .then(function () {
         return createView(dbName, viewDocId);

--- a/test/spec/doc.js
+++ b/test/spec/doc.js
@@ -606,7 +606,7 @@ describe('doc', function () {
     var dbName = utils.createdDB + '/test';
     return db.create(dbName)
       .then(function () {
-        return slouch.doc.create(dbName, doc)
+        return slouch.doc.create(dbName, doc);
       })
       .then(function (_doc) {
         doc._id = _doc.id;


### PR DESCRIPTION
Spiegel doesn't work as expected when there's forward slash in the database name and document Ids.