### PR TITLE
Add doc.find()

### DIFF
--- a/scripts/doc.js
+++ b/scripts/doc.js
@@ -298,6 +298,16 @@ Doc.prototype.all = function (dbName, params) {
   }, 'rows.*', null, this._slouch._request);
 };
 
+Doc.prototype.find = function (dbName, body, params) {
+  return this._slouch._req({
+    uri: this._slouch._url + '/' + encodeURIComponent(dbName) + '/_find',
+    method: 'POST',
+    json: body,
+    qs: params,
+    parseBody: true
+  });
+};
+
 Doc.prototype.destroyAllNonDesign = function (dbName) {
   return this.destroyAll(dbName, true);
 };

--- a/test/spec/doc.js
+++ b/test/spec/doc.js
@@ -635,7 +635,7 @@ describe('doc', function () {
   });
 
   it('should find a document by selector', function () {
-    const requestBody = {
+    var requestBody = {
       selector: {
         thing: 'findme',
       },

--- a/test/spec/doc.js
+++ b/test/spec/doc.js
@@ -6,7 +6,8 @@ var Slouch = require('../../scripts'),
   Promise = require('sporks/scripts/promise'),
   config = require('../config.json'),
   Backoff = require('backoff-promise'),
-  crypto = require("crypto");
+  crypto = require("crypto"),
+  assert = require('chai').assert;
 
 describe('doc', function () {
 
@@ -631,5 +632,25 @@ describe('doc', function () {
         newRev.should.eql(body._rev);
         return db.destroy(dbName);
       });
+  });
+
+  it('should find a document by selector', function () {
+    const requestBody = {
+      selector: {
+        thing: 'findme',
+      },
+    };
+    return slouch.doc.create(utils.createdDB, {
+      thing: 'play'
+    }).then(function () {
+      return slouch.doc.create(utils.createdDB, {
+        thing: 'findme'
+      });
+    }).then(function () {
+      return slouch.doc.find(utils.createdDB, requestBody);
+    }).then(function (body) {
+      assert.lengthOf(body.docs, 1, 'body.docs has a length of 1');
+      assert.equal(body.docs[0].thing, 'findme', '`thing` field has value `findme`');
+    });
   });
 });


### PR DESCRIPTION
This PR adds basic support for CouchDB's `/db/_find` API (see issue https://github.com/redgeoff/slouch/issues/101).

It also includes a simple test. Please let me know if something should be changed or extended. The additional function has not been added to any example or documentation file yet.