### PR TITLE
Add support for filters in change feed

### DIFF
--- a/API.md
+++ b/API.md
@@ -16,8 +16,8 @@
    * unsetIgnoreMissing(path)
  * db
    * all()
-   * changes(dbName, params)
-   * changesArray(dbName, params)
+   * [changes(dbName, params, filter)](https://github.com/redgeoff/slouch/blob/master/API.md#changesdbname-params-filter)
+   * [changesArray(dbName, params, filter)](https://github.com/redgeoff/slouch/blob/master/API.md#changesarraydbname-params-filter)
    * copy(fromDBName, toDBName)
    * create(dbName)
    * destroy(dbName)
@@ -97,6 +97,51 @@
    * toUsername(userId)
    * upsertRole(username, role)
 
+### DB
+
+#### changes(dbName, params, filter)
+
+Returns a list of changes in the database. See https://docs.couchdb.org/en/stable/api/database/changes.html for more details.
+
+The function returns an iterator that indefinitely returns changes from the database.
+
+You can use an optional third argument to pass a selector for filtering the change feed.
+
+Example:
+
+```js
+slouch.db.changes('myDB', {
+  include_docs: true,
+  feed: 'continuous',
+  heartbeat: true
+}, {
+  selector: {
+    thing: 'findme'
+  }
+});
+```
+
+#### changesArray(dbName, params, filter)
+
+Returns a list of changes in the database. See https://docs.couchdb.org/en/stable/api/database/changes.html for more details.
+
+The function returns an array of changes from the database.
+
+You can use an optional third argument to pass a selector for filtering the change feed.
+
+Example:
+
+```js
+slouch.db.changesArray('myDB', {
+  include_docs: true,
+  feed: 'continuous',
+  heartbeat: true
+}, {
+  selector: {
+    thing: 'findme'
+  }
+});
+```
 
 ### Doc
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4128,7 +4128,11 @@
           "dependencies": {
             "events": {
               "version": "1.1.1",
+<<<<<<< Updated upstream
               "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+=======
+              "resolved": "http://registry.npmjs.org/events/-/events-1.1.1.tgz",
+>>>>>>> Stashed changes
               "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
             },
             "sporks": {

--- a/test/spec/db.js
+++ b/test/spec/db.js
@@ -181,6 +181,45 @@ describe('db', function () {
     });
   });
 
+  it('should get changes with a selector', function () {
+    var changes = {};
+    return createDocs().then(function () {
+      return db.changes(utils.createdDB, {
+        include_docs: true
+      }, {
+        selector: {
+          thing: 'jam'
+        }
+      }).each(function (change) {
+        // Use associative array as order is not guaranteed
+        changes[change.doc.thing] = true;
+      });
+    }).then(function () {
+      changes.should.eql({
+        jam: true
+      });
+    });
+  });
+
+  it('should get no changes with an unknown selector', function () {
+    var changes = {};
+    return createDocs().then(function () {
+      return db.changes(utils.createdDB, {
+        include_docs: true
+      }, {
+        selector: {
+          thing: 'does-not-exist'
+        }
+      }).each(function (change) {
+        // Use associative array as order is not guaranteed
+        changes[change.doc.thing] = true;
+      });
+    }).then(function () {
+      changes.should.eql({});
+    });
+  });
+
+
   it('should get changes array', function () {
     var indexedChanges = {};
     return createDocs().then(function () {
@@ -200,6 +239,49 @@ describe('db', function () {
       });
     });
   });
+
+  it('should get changes array with a selector', function () {
+    var indexedChanges = {};
+    return createDocs().then(function () {
+      return db.changesArray(utils.createdDB, {
+        include_docs: true
+      }, {
+        selector: {
+          thing: 'jam'
+        }
+      });
+    }).then(function (changes) {
+      // Order of changes not guaranteed so we will index the values for easy comparison
+      changes.results.forEach(function (change) {
+        indexedChanges[change.doc.thing] = true;
+      });
+
+      indexedChanges.should.eql({
+        jam: true
+      });
+    });
+  });
+
+  it('should get no changes array with a unknown selector', function () {
+    var indexedChanges = {};
+    return createDocs().then(function () {
+      return db.changesArray(utils.createdDB, {
+        include_docs: true
+      }, {
+        selector: {
+          thing: 'does-not-exist'
+        }
+      });
+    }).then(function (changes) {
+      // Order of changes not guaranteed so we will index the values for easy comparison
+      changes.results.forEach(function (change) {
+        indexedChanges[change.doc.thing] = true;
+      });
+
+      indexedChanges.should.eql({});
+    });
+  });
+
 
   var waitForChange = function (thing) {
     return sporks.waitFor(function () {

--- a/test/spec/doc.js
+++ b/test/spec/doc.js
@@ -635,7 +635,7 @@ describe('doc', function () {
   });
 
   it('should find a document by selector', function () {
-    const requestBody = {
+    var requestBody = {
       selector: {
         thing: 'findme',
       },


### PR DESCRIPTION
The CouchDB `_changes` API has an option for using filters like `selector` or `doc_ids` to filter the changes that will be returned, and according to the CouchDB API documentation that has a better performance than filter functions from view documents.

This pull requests adds an additional (optional) `filter` argument to the existing functions `db.changes()` and `db.changesArray()`.

For more information, please find the official documentation:

- [POST /{db}/_changes](https://docs.couchdb.org/en/stable/api/database/changes.html#post--db-_changes)
- [Selector Syntax](https://docs.couchdb.org/en/stable/api/database/find.html#selector-syntax)