### PR TITLE
add support to request rev via HEAD

### DIFF
--- a/scripts/doc.js
+++ b/scripts/doc.js
@@ -102,7 +102,7 @@ Doc.prototype.rev = function (dbName, docId, params) {
     method: 'HEAD',
     qs: params,
     parseBody: false
-  }).then(function (headers) { return headers.etag; });
+  }).then(function (response) { return response.headers.etag; });
 };
 
 Doc.prototype.getIgnoreMissing = function (dbName, id) {

--- a/scripts/doc.js
+++ b/scripts/doc.js
@@ -95,6 +95,16 @@ Doc.prototype.get = function (dbName, docId, params) {
   });
 };
 
+Doc.prototype.rev = function (dbName, docId, params) {
+  return this._slouch._req({
+    uri: this._slouch._url + '/' + encodeURIComponent(dbName) + '/' + encodeURIComponent(
+      docId),
+    method: 'HEAD',
+    qs: params,
+    parseBody: false
+  }).then(function (headers) { return headers.etag; });
+};
+
 Doc.prototype.getIgnoreMissing = function (dbName, id) {
   var self = this;
   return self.ignoreMissing(function () {

--- a/scripts/enhanced-request.js
+++ b/scripts/enhanced-request.js
@@ -126,8 +126,8 @@ EnhancedRequest.prototype._request = function (opts) {
     // Sometimes CouchDB just returns an malformed error
     if (!response || !response.body) {
       if (response && opts.method === 'HEAD') {
-        // or we only want the response headers
-        return response.headers;
+        // or we only want the response/headers
+        return response;
       }
       err = new Error('malformed body');
       err.error = 'malformed body';


### PR DESCRIPTION
A more efficient way to get the current revision of a document by making a HEAD request.

Sorry for the formatting changes, GitHub had a mind of it's own...